### PR TITLE
Add guest mode functionality (1/3)

### DIFF
--- a/include/hardware/bluetooth.h
+++ b/include/hardware/bluetooth.h
@@ -445,7 +445,7 @@ typedef struct {
     int (*init)(bt_callbacks_t* callbacks );
 
     /** Enable Bluetooth. */
-    int (*enable)(void);
+    int (*enable)(bool guest_mode);
 
     /** Disable Bluetooth. */
     int (*disable)(void);


### PR DESCRIPTION
Add a flag to enable() to start Bluetooth in restricted
mode. In restricted mode, all devices that are paired during
restricted mode are deleted upon leaving restricted mode.
Right now restricted mode is only entered while a guest
user is active

Bug: 27410683
Change-Id: I994a2933fd60301927ff2df65da634f81d4c9428
